### PR TITLE
Enable QTI_BSP and move HWC_DISPLAY_TERTIARY to bottom of enum stack

### DIFF
--- a/24/hardware/hwcomposer.h
+++ b/24/hardware/hwcomposer.h
@@ -287,10 +287,9 @@ typedef struct hwc_layer_1 {
              */
             hwc_region_t surfaceDamage;
 
-#ifdef QTI_BSP
+            /* QTI_BSP */
             /* Color for Dim Layer */
             hwc_color_t color;
-#endif
         };
     };
 

--- a/24/hardware/hwcomposer_defs.h
+++ b/24/hardware/hwcomposer_defs.h
@@ -254,27 +254,22 @@ enum {
 enum {
     HWC_DISPLAY_PRIMARY     = 0,
     HWC_DISPLAY_EXTERNAL    = 1,    // HDMI, DP, etc.
-#ifdef QTI_BSP
-    HWC_DISPLAY_TERTIARY    = 2,
-    HWC_DISPLAY_VIRTUAL     = 3,
-
-    HWC_NUM_PHYSICAL_DISPLAY_TYPES = 3,
-    HWC_NUM_DISPLAY_TYPES          = 4,
-#else
     HWC_DISPLAY_VIRTUAL     = 2,
 
     HWC_NUM_PHYSICAL_DISPLAY_TYPES = 2,
     HWC_NUM_DISPLAY_TYPES          = 3,
-#endif
+
+    /* QTI_BSP */
+    HWC_DISPLAY_TERTIARY    = 4,
 };
 
 enum {
     HWC_DISPLAY_PRIMARY_BIT     = 1 << HWC_DISPLAY_PRIMARY,
     HWC_DISPLAY_EXTERNAL_BIT    = 1 << HWC_DISPLAY_EXTERNAL,
-#ifdef QTI_BSP
-    HWC_DISPLAY_TERTIARY_BIT    = 1 << HWC_DISPLAY_TERTIARY,
-#endif
     HWC_DISPLAY_VIRTUAL_BIT     = 1 << HWC_DISPLAY_VIRTUAL,
+
+     /* QTI_BSP */
+    HWC_DISPLAY_TERTIARY_BIT    = 1 << HWC_DISPLAY_TERTIARY,
 };
 
 /* Display power modes */


### PR DESCRIPTION
This should allow us to run both qcom and "stock aosp" with the same
binaries (for graphics at least)

This patch is also needed on the android libhardware headers for this to
work