### PR TITLE
Implement FP_ATTRIB for audio.h in android-24, -24-caf and -27

### DIFF
--- a/24-caf/hardware/audio.h
+++ b/24-caf/hardware/audio.h
@@ -32,6 +32,12 @@
 #include <listen_types.h>
 #endif
 
+#ifdef __ARM_PCS_VFP
+#define FP_ATTRIB __attribute__((pcs("aapcs")))
+#else
+#define FP_ATTRIB
+#endif
+
 __BEGIN_DECLS
 
 /**
@@ -301,7 +307,7 @@ struct audio_stream_out {
      * This method might produce multiple PCM outputs or hardware accelerated
      * codecs, such as MP3 or AAC.
      */
-    int (*set_volume)(struct audio_stream_out *stream, float left, float right);
+    int (*set_volume)(struct audio_stream_out *stream, float left, float right) FP_ATTRIB;
 
     /**
      * Write audio buffer to driver. Returns number of bytes written, or a
@@ -419,7 +425,7 @@ struct audio_stream_in {
 
     /** set the input gain for the audio driver. This method is for
      *  for future use */
-    int (*set_gain)(struct audio_stream_in *stream, float gain);
+    int (*set_gain)(struct audio_stream_in *stream, float gain) FP_ATTRIB;
 
     /** Read audio buffer in from audio driver. Returns number of bytes read, or a
      *  negative status_t. If at least one frame was read prior to the error,
@@ -550,14 +556,14 @@ struct audio_hw_device {
     int (*init_check)(const struct audio_hw_device *dev);
 
     /** set the audio volume of a voice call. Range is between 0.0 and 1.0 */
-    int (*set_voice_volume)(struct audio_hw_device *dev, float volume);
+    int (*set_voice_volume)(struct audio_hw_device *dev, float volume) FP_ATTRIB;
 
     /**
      * set the audio volume for all audio activities other than voice call.
      * Range between 0.0 and 1.0. If any value other than 0 is returned,
      * the software mixer will emulate this capability.
      */
-    int (*set_master_volume)(struct audio_hw_device *dev, float volume);
+    int (*set_master_volume)(struct audio_hw_device *dev, float volume) FP_ATTRIB;
 
     /**
      * Get the current master volume value for the HAL, if the HAL supports
@@ -566,7 +572,7 @@ struct audio_hw_device {
      * the initial master volume across all HALs.  HALs which do not support
      * this method may leave it set to NULL.
      */
-    int (*get_master_volume)(struct audio_hw_device *dev, float *volume);
+    int (*get_master_volume)(struct audio_hw_device *dev, float *volume) FP_ATTRIB;
 
     /**
      * set_mode is called when the audio mode changes. AUDIO_MODE_NORMAL mode

--- a/24/hardware/audio.h
+++ b/24/hardware/audio.h
@@ -32,6 +32,12 @@
 #include <listen_types.h>
 #endif
 
+#ifdef __ARM_PCS_VFP
+#define FP_ATTRIB __attribute__((pcs("aapcs")))
+#else
+#define FP_ATTRIB
+#endif
+
 __BEGIN_DECLS
 
 /**
@@ -301,7 +307,7 @@ struct audio_stream_out {
      * This method might produce multiple PCM outputs or hardware accelerated
      * codecs, such as MP3 or AAC.
      */
-    int (*set_volume)(struct audio_stream_out *stream, float left, float right);
+    int (*set_volume)(struct audio_stream_out *stream, float left, float right) FP_ATTRIB;
 
     /**
      * Write audio buffer to driver. Returns number of bytes written, or a
@@ -419,7 +425,7 @@ struct audio_stream_in {
 
     /** set the input gain for the audio driver. This method is for
      *  for future use */
-    int (*set_gain)(struct audio_stream_in *stream, float gain);
+    int (*set_gain)(struct audio_stream_in *stream, float gain) FP_ATTRIB;
 
     /** Read audio buffer in from audio driver. Returns number of bytes read, or a
      *  negative status_t. If at least one frame was read prior to the error,
@@ -550,14 +556,14 @@ struct audio_hw_device {
     int (*init_check)(const struct audio_hw_device *dev);
 
     /** set the audio volume of a voice call. Range is between 0.0 and 1.0 */
-    int (*set_voice_volume)(struct audio_hw_device *dev, float volume);
+    int (*set_voice_volume)(struct audio_hw_device *dev, float volume) FP_ATTRIB;
 
     /**
      * set the audio volume for all audio activities other than voice call.
      * Range between 0.0 and 1.0. If any value other than 0 is returned,
      * the software mixer will emulate this capability.
      */
-    int (*set_master_volume)(struct audio_hw_device *dev, float volume);
+    int (*set_master_volume)(struct audio_hw_device *dev, float volume) FP_ATTRIB;
 
     /**
      * Get the current master volume value for the HAL, if the HAL supports
@@ -566,7 +572,7 @@ struct audio_hw_device {
      * the initial master volume across all HALs.  HALs which do not support
      * this method may leave it set to NULL.
      */
-    int (*get_master_volume)(struct audio_hw_device *dev, float *volume);
+    int (*get_master_volume)(struct audio_hw_device *dev, float *volume) FP_ATTRIB;
 
     /**
      * set_mode is called when the audio mode changes. AUDIO_MODE_NORMAL mode

--- a/27/hardware/audio.h
+++ b/27/hardware/audio.h
@@ -30,6 +30,12 @@
 #include <system/audio.h>
 #include <hardware/audio_effect.h>
 
+#ifdef __ARM_PCS_VFP
+#define FP_ATTRIB __attribute__((pcs("aapcs")))
+#else
+#define FP_ATTRIB
+#endif
+
 __BEGIN_DECLS
 
 /**
@@ -228,7 +234,7 @@ struct audio_stream_out {
      * This method might produce multiple PCM outputs or hardware accelerated
      * codecs, such as MP3 or AAC.
      */
-    int (*set_volume)(struct audio_stream_out *stream, float left, float right);
+    int (*set_volume)(struct audio_stream_out *stream, float left, float right) FP_ATTRIB;
 
     /**
      * Write audio buffer to driver. Returns number of bytes written, or a
@@ -405,7 +411,7 @@ struct audio_stream_in {
 
     /** set the input gain for the audio driver. This method is for
      *  for future use */
-    int (*set_gain)(struct audio_stream_in *stream, float gain);
+    int (*set_gain)(struct audio_stream_in *stream, float gain) FP_ATTRIB;
 
     /** Read audio buffer in from audio driver. Returns number of bytes read, or a
      *  negative status_t. If at least one frame was read prior to the error,
@@ -595,14 +601,14 @@ struct audio_hw_device {
     int (*init_check)(const struct audio_hw_device *dev);
 
     /** set the audio volume of a voice call. Range is between 0.0 and 1.0 */
-    int (*set_voice_volume)(struct audio_hw_device *dev, float volume);
+    int (*set_voice_volume)(struct audio_hw_device *dev, float volume) FP_ATTRIB;
 
     /**
      * set the audio volume for all audio activities other than voice call.
      * Range between 0.0 and 1.0. If any value other than 0 is returned,
      * the software mixer will emulate this capability.
      */
-    int (*set_master_volume)(struct audio_hw_device *dev, float volume);
+    int (*set_master_volume)(struct audio_hw_device *dev, float volume) FP_ATTRIB;
 
     /**
      * Get the current master volume value for the HAL, if the HAL supports
@@ -611,7 +617,7 @@ struct audio_hw_device {
      * the initial master volume across all HALs.  HALs which do not support
      * this method may leave it set to NULL.
      */
-    int (*get_master_volume)(struct audio_hw_device *dev, float *volume);
+    int (*get_master_volume)(struct audio_hw_device *dev, float *volume) FP_ATTRIB;
 
     /**
      * set_mode is called when the audio mode changes. AUDIO_MODE_NORMAL mode

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+android-headers (27.0ubports2) xenial; urgency=medium
+
+  * Implement FP_ATTRIB for audio.h in android-24, -24-caf and -27
+
+ -- Ratchanan Srirattanamet <ratchanan@ubports.com>  Tue, 29 Oct 2019 21:05:14 +0700
+
 android-headers (27.0ubports1) xenial; urgency=medium
 
   * Import android-27 headers


### PR DESCRIPTION
Android always compile its code with --mfloat-abi=softfp. To ensure
correct linkage, `__attribute__((pcs("aapcs")))` must be added to
every function that pass or return floating point values.

See fe520104ea3596fff542da40317894d279bdc033 (audio.h: handling the
float based function calls with aapcs.)